### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@6.0.0
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: test-kitchen
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   lint-unit:
     uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     with:
+      gems: rake
       platform: windows-latest
     permissions:
       actions: write

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: Install Chef
-        uses: actionshub/chef-install@main
+      - name: Install Cinc Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Cookbook Scope
+
+The `notepadpp` cookbook installs Notepad++ on Windows using `windows_package`.
+
+## Policyfile Migration Notes
+
+* Dependency resolution is Policyfile-first. Do not reintroduce `Berksfile` or `berks install`.
+* The integration suite uses `minitest-handler`; there are no InSpec profiles in this cookbook.
+* `kitchen.exec.yml` intentionally uses the `dummy` verifier so the Windows exec run does not
+  inherit an InSpec verifier with no profile.
+* `windows` is resolved from the sous-chefs GitHub repository to avoid Supermarket dependency
+  resolution during CI.

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-cookbook 'minitest-handler', github: 'b-dean/minitest-handler-cookbook', branch: 'chef-13-fix'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+name 'notepadpp'
+
+run_list 'notepadpp::default', 'minitest-handler::default'
+
+named_run_list :default, 'notepadpp::default', 'minitest-handler::default'
+
+cookbook 'notepadpp', path: '.'
+cookbook 'minitest-handler',
+         git: 'https://github.com/b-dean/minitest-handler-cookbook.git',
+         branch: 'chef-13-fix'
+cookbook 'chef_handler',
+         git: 'https://github.com/chef-boneyard/chef_handler.git',
+         branch: 'master'
+cookbook 'windows',
+         git: 'https://github.com/chef-boneyard/windows.git',
+         branch: 'master'

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -6,7 +6,8 @@ transport:
   name: exec
 
 provisioner:
-  chef_omnibus_install: false
+  product_name: cinc
+  install_strategy: skip
 
 verifier:
   name: dummy

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -5,6 +5,9 @@ driver:
 transport:
   name: exec
 
+provisioner:
+  chef_omnibus_install: false
+
 verifier:
   name: dummy
 

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -5,6 +5,9 @@ driver:
 transport:
   name: exec
 
+verifier:
+  name: dummy
+
 platforms:
   - name: windows-latest
   - name: macos-latest

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,8 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: policyfile_zero
+  policyfile: Policyfile.rb
 
 platforms:
   - name: windows-2019
@@ -15,6 +16,8 @@ suites:
     run_list:
       - recipe[notepadpp]
       - recipe[minitest-handler]
+    provisioner:
+      named_run_list: default
 
 verifier:
-  name: inspec
+  name: dummy

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'notepadpp::default' do
   describe '32-bit Windows' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
+      ChefSpec::SoloRunner.new do |node|
         node.automatic['kernel']['machine'] = 'i386'
       end.converge(described_recipe)
     end
@@ -18,7 +18,7 @@ describe 'notepadpp::default' do
 
   describe '64-bit Windows' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
+      ChefSpec::SoloRunner.new do |node|
         node.automatic['kernel']['machine'] = 'x86_64'
       end.converge(described_recipe)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 require 'rspec/expectations'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary
- replace Berkshelf dependency resolution with Policyfile
- use explicit GitHub cookbook sources for minitest-handler, chef_handler, and windows
- switch Kitchen to Policyfile named run list and dummy verifier for Windows exec
- update sous-chefs workflow/action pins to 8.0.4

## Validation
- chef update Policyfile.rb
- chef install Policyfile.rb
- cookstyle
- embedded RSpec: 2 examples, 0 failures
- markdownlint-cli2 .
- yamllint .
- actionlint
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.exec.yml kitchen list
- KITCHEN_LOCAL_YAML=kitchen.exec.yml kitchen diagnose default-windows-latest --loader --no-instances

Focused Kitchen converge is Windows-runner only for this cookbook; local validation confirms Kitchen resolves PolicyfileZero with Dummy verifier for the windows-latest exec instance.